### PR TITLE
fix svg clipped bug

### DIFF
--- a/src/editor/items/DomItem.js
+++ b/src/editor/items/DomItem.js
@@ -759,14 +759,13 @@ ${this.toSelectorString(prefix)}
     var tagName = elementType || 'div'
     var css = this.toCSS();
 
+    delete css.left;
+    delete css.top;      
+    if (css.position === 'absolute') {
+      delete css.position; 
+    }
+
     if (isRoot) {
-
-      delete css.left;
-      delete css.top;      
-      if (css.position === 'absolute') {
-        delete css.position; 
-      }
-
       return this.wrapperRootSVG(x, y, width, height, /*html*/`
         <g transform="translate(${x}, ${y})">      
           <foreignObject ${OBJECT_TO_PROPERTY({ 


### PR DESCRIPTION
안녕하세요 :) @easylogic 
멋진 툴을 개발해주셔서 감사합니다 👍 

저는 에디터에 도형을 그린 뒤에 svg 포멧으로 export 하는 용도로 사용하려고 하는데요.

svg 로 export 하게되면 `g`, `foreignObject` 태그가  **dom 엘리먼트**를 감싸면서 `g` 의 `x`, `y` 를 기준으로 **dom 엘리먼트**가 위치하게 됩니다. 그런데 **dom 엘리먼트** 의 `left`, `top` 속성이 그대로 남아있어서, `foreignObject` 바깥으로 밀리는 현상이 있습니다.

```
g(x, y) ---------------
|                      |
|                      |
| ------- dom (left, top)

```

[이전 commit](https://github.com/easylogic/editor/commit/19087e458e2d19f95bf7b28f0dd9ab86d899a8e1#diff-2955dfffa0916eb8bf0ccb01afcc4709) 을 보니 root 일 경우에만 left, right 를 제거하도록 의도된 것 같은데, 혹시 몰라서 PR 작성해봅니다.

### 현상

1. 상단 툴바에서 rect 를 선택해 그린 후
2. 좌 하단 export 클릭 -> SVG Image preview 탭으로 이동
3. rect 가 짤린 것을 확인할 수 있음

#### case 1
 * editor
<img width="500" alt="스크린샷 2020-06-27 오전 12 55 37" src="https://user-images.githubusercontent.com/41323220/85877032-81cef400-b811-11ea-997b-2d71258fa44a.png">

  * preview
<img width="500" alt="스크린샷 2020-06-27 오전 12 56 23" src="https://user-images.githubusercontent.com/41323220/85877064-8bf0f280-b811-11ea-89a5-36dab566e925.png">

#### case 2
  * editor
<img width="500" alt="스크린샷 2020-06-27 오전 12 56 42" src="https://user-images.githubusercontent.com/41323220/85877133-a4f9a380-b811-11ea-8301-3e0aa73ff669.png">

  * preview
<img width="500" alt="스크린샷 2020-06-27 오전 12 56 51" src="https://user-images.githubusercontent.com/41323220/85877171-b6db4680-b811-11ea-898a-2b6107a1e515.png">
