### PR TITLE
fix project reference in PathDrawView

### DIFF
--- a/src/editor-layouts/common/body-panel/render-view/draw-panels/PathDrawView.js
+++ b/src/editor-layouts/common/body-panel/render-view/draw-panels/PathDrawView.js
@@ -106,7 +106,7 @@ export default class PathDrawView extends EditorElement {
             if (this.state[key]) Object.assign(pathItem, {[key]: this.state[key] })    
         });            
 
-        layer = project.appendChild(this.$editor.createModel(pathItem));      
+        layer = this.$selection.currentProject.appendChild(this.$editor.createModel(pathItem));      
 
         return layer; 
     }


### PR DESCRIPTION
<img width="298" alt="스크린샷 2021-09-06 오후 9 53 27" src="https://user-images.githubusercontent.com/22005861/132220551-52b8b774-9d5b-484f-a372-40790e0d09e0.png">

draw 사용 시 reference error가 발생하는 것을 수정합니다. 기존의 다른 코드 참고해서 currentProject로 변경해봤습니다.

원래 정상적으로 동작하는 draw가 어떻게 되는지 잘 몰라서 제대로 동작하는 건지 한번 봐주시면 좋을 것 같아요

https://user-images.githubusercontent.com/22005861/132220754-4220d966-8011-4b03-97ba-60e24deccca8.mov

